### PR TITLE
Match README.md to file names and contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ are not authenticated at this point.
 The HTML5 application is a basic web application that is secured with the Keycloak JavaScript adapter.
 You can login to the application through Keycloak and then securely invoke the Node.js service.
 
-Simply run `bin/start-app-php.sh` and the application will be deployed to OpenShift.
+Simply run `bin/start-app.sh` and the application will be deployed to OpenShift.
  
 To find the hostname of the service run `oc get routes demo-app`. Then open `https://<hostname>/public` 
-in your favorite browser. Click on the login button and login with username `keycloak` and password `test`.
+in your favorite browser. Click on the login button and login with username `keycloak` and password `pass`.
 Now you can click on the various buttons to invoke different endpoints on the service.
 
 You won't be able to invoke the admin endpoint at this point as the `keycloak` user doesn't have the required


### PR DESCRIPTION
There is no fail named bin/start-app-php.sh. The file is called bin/startapp.sh.

The demo-realm.json file sets the "keycloak" password to "pass" not "test" as in the README.md file:
            "credentials": [
                {
                    "type": "password",
                    "value": "pass"
                }
            ],